### PR TITLE
Deep links

### DIFF
--- a/loopr-ios/AppDelegate.swift
+++ b/loopr-ios/AppDelegate.swift
@@ -107,12 +107,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 vc.order = TradeDataManager.shared.orders[1]
                 window?.rootViewController = vc
             }
-        }
-        let queryArray = url.absoluteString.components(separatedBy: "/")
-        let unescaped = queryArray[2].removingPercentEncoding!
-        AuthorizeDataManager.shared.process(qrContent: unescaped)
-        if let main = self.window?.rootViewController as? MainTabController {
-            main.processExternalUrl()
+        } else {
+            let queryArray = url.absoluteString.components(separatedBy: "/")
+            let unescaped = queryArray[2].removingPercentEncoding!
+            AuthorizeDataManager.shared.process(qrContent: unescaped)
+            if let main = self.window?.rootViewController as? MainTabController {
+                main.processExternalUrl()
+            }
         }
         return true
     }


### PR DESCRIPTION
Deeplinks support added.
Example of the deeplink:
`
loopr-ios://p2p/Hash=PUTHASHHERE&Ratio=1&Auth=PUTAUTHHERE
`
This could be formed instead of current QR code with JSON in it.